### PR TITLE
Fixed confusing matching brace highlight color-scheme for terminal vim

### DIFF
--- a/colors/kolor.vim
+++ b/colors/kolor.vim
@@ -233,9 +233,9 @@ if &t_Co > 255
     highlight Keyword         ctermfg=168     ctermbg=none    cterm=none
     highlight Title           ctermfg=141     ctermbg=none    cterm=none
     if g:kolor_alternative_matchparen==0
-      highlight MatchParen      ctermfg=235     ctermbg=206     cterm=none
+      highlight MatchParen      ctermfg=255     ctermbg=125     cterm=none
     else
-      highlight MatchParen      ctermfg=235     ctermbg=247     cterm=none
+      highlight MatchParen      ctermfg=251     ctermbg=241     cterm=none
     endif
   else
     highlight ErrorMsg        ctermfg=168     ctermbg=none    cterm=bold
@@ -252,9 +252,9 @@ if &t_Co > 255
     highlight Keyword         ctermfg=168     ctermbg=none    cterm=bold
     highlight Title           ctermfg=141     ctermbg=none    cterm=bold
     if g:kolor_alternative_matchparen==0
-      highlight MatchParen      ctermfg=235     ctermbg=206     cterm=bold
+      highlight MatchParen      ctermfg=255     ctermbg=125     cterm=bold
     else
-      highlight MatchParen      ctermfg=235     ctermbg=247     cterm=bold
+      highlight MatchParen      ctermfg=251     ctermbg=241     cterm=bold
     endif
   endif
   if g:kolor_underlined==0


### PR DESCRIPTION
While using the color-scheme in terminal vim, the matching brace highlighting becomes confusing.

![confusing](https://user-images.githubusercontent.com/22937307/27259532-2c9025ee-53e3-11e7-898a-3d187ded1ca1.gif)

As shown in this gif, when cursor lands on a brace its bgcolor becomes black and the bgcolor of the matching brace becomes magenta, which becomes confusing while navigating through file,
Here is my fix: 

![fixed](https://user-images.githubusercontent.com/22937307/27259561-9c6e9206-53e3-11e7-9c24-1d14d0355216.gif)
I changed the bgcolor of cursor to white when it lands on a brace to avoid confusion.